### PR TITLE
docs: add LLM reporting guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -45,7 +45,8 @@
               "outputs/derivatives_overview",
               "outputs/intermediate_steps",
               "outputs/subject_reports",
-              "outputs/metadata_logs"
+              "outputs/metadata_logs",
+              "outputs/llm_reports"
             ]
           },
 

--- a/outputs/llm_reports.mdx
+++ b/outputs/llm_reports.mdx
@@ -9,9 +9,15 @@ language model. These reports live under each subject's
 `metadata/llm_reports` folder and are built from the processing log and
 PDF report.
 
-<!-- markdownlint-disable-next-line MD033 -->
+
 <Info>By default AI reporting is disabled. Set `"ai_reporting": true`
 in task config and provide `OPENAI_API_KEY` to enable.</Info>
+
+<Warning>
+**Privacy Considerations for LLM Reporting**
+
+For 100% privacy, use a local language model instead of cloud-based APIs. When using OpenAI's API, ensure your setup includes zero data retention and a Business Associate Agreement (BAA) if handling Protected Health Information (PHI). Note that most data sent is deidentified and consists of aggregate processing metrics, not raw EEG data.
+</Warning>
 
 ## Files Produced
 
@@ -19,9 +25,7 @@ in task config and provide `OPENAI_API_KEY` to enable.</Info>
 |------|---------|
 | `context.json` | Serialized run context used to produce all text. |
 | `methods.md` | Deterministic methods paragraph created without any API calls. |
-<!-- markdownlint-disable-next-line MD013 -->
 | `executive_summary.md` | Study-ready summary produced by the LLM (requires API key). |
-<!-- markdownlint-disable-next-line MD013 -->
 | `qc_narrative.md` | LLM-generated quality control narrative and recommendations (requires API key). |
 | `llm_trace.jsonl` | Hash-based trace of prompts and results for compliance. |
 
@@ -56,6 +60,5 @@ key is present, it also generates `executive_summary.md` and
 - Capture deterministic methods text for manuscripts.
 - Quickly review quality metrics without opening the full PDF.
 
-<!-- markdownlint-disable-next-line MD033 -->
 <Info>Missing API keys or expected input files never break your run; the
 pipeline simply skips LLM outputs.</Info>

--- a/outputs/llm_reports.mdx
+++ b/outputs/llm_reports.mdx
@@ -1,0 +1,61 @@
+---
+title: "Derivatives: LLM Reports"
+sidebarTitle: "Folder: LLM Reports"
+description: "Opt-in AI-generated summaries from pipeline runs."
+---
+
+AutoCleanEEG can optionally generate textual summaries using a large
+language model. These reports live under each subject's
+`metadata/llm_reports` folder and are built from the processing log and
+PDF report.
+
+<!-- markdownlint-disable-next-line MD033 -->
+<Info>By default AI reporting is disabled. Set `"ai_reporting": true`
+in task config and provide `OPENAI_API_KEY` to enable.</Info>
+
+## Files Produced
+
+| File | Purpose |
+|------|---------|
+| `context.json` | Serialized run context used to produce all text. |
+| `methods.md` | Deterministic methods paragraph created without any API calls. |
+<!-- markdownlint-disable-next-line MD013 -->
+| `executive_summary.md` | Study-ready summary produced by the LLM (requires API key). |
+<!-- markdownlint-disable-next-line MD013 -->
+| `qc_narrative.md` | LLM-generated quality control narrative and recommendations (requires API key). |
+| `llm_trace.jsonl` | Hash-based trace of prompts and results for compliance. |
+
+## Enabling the Feature
+
+1. Add `"ai_reporting": true` to your task configuration or workspace
+   template.
+2. Ensure an `OPENAI_API_KEY` is available in the environment.
+3. Run the pipeline as usual – reports appear under:
+
+```text
+bids/derivatives/autoclean-v<version>/metadata/llm_reports/
+```
+
+## CLI Usage
+
+You can regenerate reports or chat about a run from the command line:
+
+```bash
+autocleaneeg-pipeline report create --run-id demo --context-json ./context.json \
+  --out-dir ./reports
+autocleaneeg-pipeline report chat --context-json ./context.json
+```
+
+`report create` always writes `context.json` and `methods.md`. If an API
+key is present, it also generates `executive_summary.md` and
+`qc_narrative.md`.
+
+## When to Use
+
+- Share short summaries with collaborators.
+- Capture deterministic methods text for manuscripts.
+- Quickly review quality metrics without opening the full PDF.
+
+<!-- markdownlint-disable-next-line MD033 -->
+<Info>Missing API keys or expected input files never break your run; the
+pipeline simply skips LLM outputs.</Info>


### PR DESCRIPTION
## Summary
- document optional LLM-based reporting outputs and how to enable them
- link LLM report docs in navigation

## Testing
- `npx markdownlint-cli outputs/llm_reports.mdx docs.json`


------
https://chatgpt.com/codex/tasks/task_e_68bdfe7f2d208322b8df1561878bbbc9