### PR TITLE
docs: add protocol pages for common EEG pipelines

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -111,6 +111,12 @@
             ]
           }
         ]
+      },
+      {
+        "tab": "EEG Montages",
+        "pages": [
+          "montages/biosemi32-infant"
+        ]
       }
     ],
     "global": {

--- a/docs.json
+++ b/docs.json
@@ -90,6 +90,27 @@
             ]
           }
         ]
+      },
+      {
+        "tab": "Protocols",
+        "groups": [
+          {
+            "group": "Resting State",
+            "pages": [
+              "protocols/resting_state_basic"
+            ]
+          },
+          {
+            "group": "Public Pipelines",
+            "pages": [
+              "protocols/made_pipeline",
+              "protocols/faster",
+              "protocols/happe",
+              "protocols/prep_pipeline",
+              "protocols/automagic"
+            ]
+          }
+        ]
       }
     ],
     "global": {

--- a/montages/biosemi32-infant.mdx
+++ b/montages/biosemi32-infant.mdx
@@ -1,0 +1,101 @@
+---
+title: Custom Montage Example - BioSemi32 Infant
+description: Example showing how to add custom montage support using BioSemi 32‑channel Infant BDF as a case study
+---
+
+# Custom Montage Example: BioSemi32 Infant Import
+
+This guide demonstrates how to add support for custom montages in AutoCleanEEG using the BioSemi 32‑channel infant cap as a real-world example. Follow this pattern to add support for your own custom montage configurations.
+
+## Why Custom Montages?
+
+Many EEG systems use non-standard channel naming or custom electrode layouts. This example shows how the BioSemi infant cap plugin remaps generic `A1–A32` labels to standard names, sets channel types, and applies proper montage positioning.
+
+<Steps>
+  <Step title="Add the EEG plugin">
+    The new plugin lives at `src/autoclean/plugins/eeg_plugins/bdf_biosemi32_infant_plugin.py` and implements `BiosemiBDFInfantPlugin`.
+
+    What it does:
+    - Loads BDF via `mne.io.read_raw_bdf(...)`.
+    - Renames `A1–A32` → standard BioSemi32 names (e.g., `A1 → Fp1`, `A31 → Fz`, `A32 → Cz`).
+    - Sets auxiliary channels to the right types (e.g., `EXG1/EXG2` → `eog`, `EXG3` → `ecg`, `Resp` → `resp`).
+    - Applies the `biosemi32` montage with `raw.set_montage(..., match_case=False)`.
+
+    The plugin advertises support for the combination `(format: BIOSEMI_BDF, montage: biosemi32_infant)` so it's auto‑registered during plugin discovery.
+  </Step>
+
+  <Step title="Expose the montage in discovery">
+    The import system now includes `biosemi32_infant` in its discovery set so compatible plugins are registered:
+
+    - File: `src/autoclean/io/import_.py`
+    - List: `test_montages = [ ..., "biosemi32_infant", ... ]`
+
+    This allows `get_plugin_for_combination(format_id, montage_name)` to select `BiosemiBDFInfantPlugin` when your config sets `eeg_system: biosemi32_infant` and the file extension is `.bdf`.
+  </Step>
+
+  <Step title="Add the montage to configuration">
+    Ensure your montage list includes an entry for validation:
+
+    - File: `configs/montages.yaml`
+    - Add: `biosemi32_infant: "BioSemi 32 (Infant)"` under `valid_montages:`
+
+    This keeps `validate_eeg_system(...)` happy when tasks reference `biosemi32_infant`.
+  </Step>
+
+  <Step title="Use it in a Python task">
+    In Python task files, add the montage to your config dictionary:
+
+    ```python
+    config = {
+        "unprocessed_file": "/path/to/recording.bdf",
+        "montage": {
+            "enabled": True,
+            "value": "biosemi32_infant",  # Your custom montage name
+        },
+    }
+    ```
+
+    The pipeline will discover `BIOSEMI_BDF` from the `.bdf` extension and select the infant plugin automatically.
+  </Step>
+
+  <Step title="Use it in a YAML task">
+    For YAML-based configurations, the structure mirrors the Python dict:
+
+    ```yaml
+    tasks:
+      my_infant_task:
+        settings:
+          montage:
+            enabled: true
+            value: biosemi32_infant
+    unprocessed_file: /path/to/recording.bdf
+    ```
+
+    Both approaches achieve the same result - the pipeline uses your custom montage plugin.
+  </Step>
+
+  <Step title="Verify the import">
+    You should see logs like:
+
+    - `Using plugin: BiosemiBDFInfantPlugin`
+    - `Successfully loaded BDF file`
+    - `Electrodes were assigned to the biosemi32 montage`
+
+    In `raw.info`:
+    - EEG channels renamed to standard BioSemi32 names (e.g., `Fp1, AF3, ... Cz`).
+    - Non‑EEG channels have correct types (`eog`, `ecg`, `emg`, `resp`, `misc`).
+  </Step>
+</Steps>
+
+## Notes & Tips
+
+- Channel mapping is defined in `CHANNEL_MAPPING` inside the plugin; adjust if your BioSemi32 infant cap uses a custom layout.
+- Auxiliary channel typing is set via `NON_EEG_TYPES`; extend if your device exports additional channels.
+- The montage applied is `biosemi32` (electrode positions) while the user‑facing system string is `biosemi32_infant` (import behavior + mapping).
+- Troubleshooting: If validation fails, confirm `biosemi32_infant` exists in `configs/montages.yaml` and that your input file is `.bdf`.
+
+## Related Files
+
+- `src/autoclean/plugins/eeg_plugins/bdf_biosemi32_infant_plugin.py`
+- `src/autoclean/io/import_.py`
+- `configs/montages.yaml`

--- a/protocols/automagic.mdx
+++ b/protocols/automagic.mdx
@@ -1,0 +1,24 @@
+---
+title: "Automagic"
+description: "Automated modular pipeline with quality metrics for EEG preprocessing."
+---
+
+<Tabs>
+<Tab title="Overview">
+<Note>
+Automagic (Pedroni et al., 2019) combines artifact rejection modules with
+automatic quality reports for large EEG datasets.
+</Note>
+</Tab>
+<Tab title="Steps">
+<Steps>
+<Step title="Import raw EEG in EEGLAB format" />
+<Step title="Apply band-pass and notch filters" />
+<Step title="Detect bad channels and segments using multiple criteria" />
+<Step title="Run ICA and classify components with ICLabel" />
+<Step title="Compute quality metrics and flag low-quality recordings" />
+<Step title="Export cleaned data and HTML reports" />
+</Steps>
+</Tab>
+</Tabs>
+

--- a/protocols/faster.mdx
+++ b/protocols/faster.mdx
@@ -1,0 +1,25 @@
+---
+title: "FASTER"
+description: "Fully Automated Statistical Thresholding for EEG artifact Rejection."
+---
+
+<Tabs>
+<Tab title="Overview">
+<Note>
+FASTER (Nolan et al., 2010) uses statistical thresholds at channel, epoch, and
+component levels to clean EEG without manual intervention.
+</Note>
+</Tab>
+<Tab title="Steps">
+<Steps>
+<Step title="Band-pass filter 1–80 Hz and remove line noise" />
+<Step title="Identify noisy channels via variance, correlation, and Hurst exponent" />
+<Step title="Interpolate rejected channels and rereference to average" />
+<Step title="Segment data into epochs" />
+<Step title="Reject epochs exceeding amplitude, variance, or kurtosis thresholds" />
+<Step title="Run ICA and score components on spatial/temporal statistics" />
+<Step title="Remove artifactual components and reconstruct cleaned signal" />
+</Steps>
+</Tab>
+</Tabs>
+

--- a/protocols/happe.mdx
+++ b/protocols/happe.mdx
@@ -1,0 +1,24 @@
+---
+title: "HAPPE"
+description: "Harvard Automated Processing Pipeline for Electroencephalography."
+---
+
+<Tabs>
+<Tab title="Overview">
+<Note>
+HAPPE (Gabard-Durnam et al., 2018) targets high-artifact developmental EEG using
+wavelet-enhanced ICA and automated component rejection.
+</Note>
+</Tab>
+<Tab title="Steps">
+<Steps>
+<Step title="Import EEGLAB .set files and standardize channel labels" />
+<Step title="Apply 1–100 Hz band-pass and 60 Hz notch filters" />
+<Step title="Detect bad channels via correlation, flat segments, and extreme amplitude" />
+<Step title="Run wavelet-enhanced ICA" />
+<Step title="Reject artifactual components with MARA and residual variance metrics" />
+<Step title="Rereference to average and export cleaned data" />
+</Steps>
+</Tab>
+</Tabs>
+

--- a/protocols/made_pipeline.mdx
+++ b/protocols/made_pipeline.mdx
@@ -1,0 +1,28 @@
+---
+title: "MADE Pipeline"
+description: "Maryland Analysis of Developmental EEG (MADE) automated preprocessing."
+---
+
+<Tabs>
+<Tab title="Overview">
+<Note>
+MADE is a MATLAB-based pipeline for developmental EEG that standardizes filtering,
+artifact removal, and epoching (Debnath et al., 2020).
+</Note>
+</Tab>
+<Tab title="Steps">
+<Steps>
+<Step title="Import raw EEG and metadata" />
+<Step title="Resample to 250 Hz and apply 0.3–45 Hz band-pass filter" />
+<Step title="Remove 60 Hz line noise" />
+<Step title="Detect noisy channels via spectral and correlation metrics" />
+<Step title="Interpolate rejected channels" />
+<Step title="Rereference to average" />
+<Step title="Run ICA (extended infomax)" />
+<Step title="Reject artifact components with ADJUST" />
+<Step title="Epoch events and apply FASTER-based rejection" />
+<Step title="Export cleaned data and summary stats" />
+</Steps>
+</Tab>
+</Tabs>
+

--- a/protocols/prep_pipeline.mdx
+++ b/protocols/prep_pipeline.mdx
@@ -1,0 +1,24 @@
+---
+title: "PREP Pipeline"
+description: "Preprocessing Pipeline for EEG referencing and line-noise removal."
+---
+
+<Tabs>
+<Tab title="Overview">
+<Note>
+The PREP pipeline (Bigdely-Shamlo et al., 2015) provides standardized steps for
+line-noise removal and robust average referencing prior to analysis.
+</Note>
+</Tab>
+<Tab title="Steps">
+<Steps>
+<Step title="Remove line noise with notch or CleanLine" />
+<Step title="High-pass filter at 1 Hz" />
+<Step title="Detect bad channels via deviation, correlation, and noisiness criteria" />
+<Step title="Interpolate bad channels" />
+<Step title="Compute robust average reference" />
+<Step title="Return cleaned, referenced dataset" />
+</Steps>
+</Tab>
+</Tabs>
+

--- a/protocols/resting_state_basic.mdx
+++ b/protocols/resting_state_basic.mdx
@@ -1,0 +1,84 @@
+---
+title: "Resting State – Basic"
+description: "Template task for resting-state EEG preprocessing."
+---
+
+<Note>
+This protocol mirrors the default `RestingState_Basic` task from the AutoCleanEEG pipeline.
+</Note>
+
+<Tabs>
+<Tab title="Config">
+```python
+config = {
+    "move_flagged_files": False,
+    "resample_step": {"enabled": True, "value": 250},
+    "filtering": {
+        "enabled": True,
+        "value": {
+            "l_freq": 1,
+            "h_freq": 100,
+            "notch_freqs": [60, 120],
+            "notch_widths": 5,
+        },
+    },
+    "drop_outerlayer": {"enabled": False, "value": []},
+    "eog_step": {
+        "enabled": False,
+        "value": [1, 32, 8, 14, 17, 21, 25, 125, 126, 127, 128],
+    },
+    "trim_step": {"enabled": True, "value": 4},
+    "crop_step": {"enabled": False, "value": {"start": 0, "end": 60}},
+    "reference_step": {"enabled": True, "value": "average"},
+    "montage": {"enabled": True, "value": "GSN-HydroCel-129"},
+    "ICA": {
+        "enabled": True,
+        "value": {
+            "method": "infomax",
+            "n_components": None,
+            "fit_params": {"extended": True},
+            "temp_highpass_for_ica": 1.0,
+        },
+    },
+    "component_rejection": {
+        "enabled": True,
+        "method": "icvision",
+        "value": {
+            "ic_flags_to_reject": ["muscle", "heart", "eog", "ch_noise", "line_noise"],
+            "ic_rejection_threshold": 0.3,
+        },
+    },
+    "epoch_settings": {
+        "enabled": True,
+        "value": {"tmin": -1, "tmax": 1},
+        "event_id": None,
+        "remove_baseline": {"enabled": False, "window": [None, 0]},
+        "threshold_rejection": {"enabled": False, "volt_threshold": {"eeg": 0.000125}},
+    },
+}
+```
+</Tab>
+<Tab title="Pipeline Steps">
+<Steps>
+<Step title="Import raw data" />
+<Step title="Resample data" />
+<Step title="Filter data" />
+<Step title="Drop outer layer" />
+<Step title="Assign EOG channels" />
+<Step title="Trim edges" />
+<Step title="Crop duration" />
+<Step title="Clean bad channels" />
+<Step title="Re-reference" />
+<Step title="Annotate noisy epochs" />
+<Step title="Annotate uncorrelated epochs" />
+<Step title="Detect dense oscillatory artifacts" />
+<Step title="Run ICA" />
+<Step title="Classify ICA components" />
+<Step title="Create regular epochs" />
+<Step title="Detect outlier epochs" />
+<Step title="GFP clean epochs" />
+<Step title="Generate reports" />
+</Steps>
+</Tab>
+</Tabs>
+


### PR DESCRIPTION
## Summary
- expand Protocols navigation with detailed pages for MADE, FASTER, HAPPE, PREP, and Automagic pipelines
- present each protocol with Mintlify Tabs and Step lists for quick reference

## Testing
- `pre-commit run --files docs.json protocols/made_pipeline.mdx protocols/faster.mdx protocols/happe.mdx protocols/prep_pipeline.mdx protocols/automagic.mdx` *(fails: InvalidConfigError: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68c126bdae68832289ac30980e29f9ab